### PR TITLE
Fix HTTP mixed content issue and mitigate potential loading timeout.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3135,11 +3135,11 @@
       "dev": true
     },
     "dc-extensions-sdk": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dc-extensions-sdk/-/dc-extensions-sdk-1.0.3.tgz",
-      "integrity": "sha512-df7D60J9MaeAEysL/oNFPzihhNpSjmrppMrWpgWNH7RKPtRYo+Ld4l1z5A9wU2sDCpjSDOYc3bhfszd5RDrOww==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dc-extensions-sdk/-/dc-extensions-sdk-1.1.0.tgz",
+      "integrity": "sha512-PF5GRkA0eV2yCWwf4crCPO6mW8Finy1UpEd6EpfHtdwky02PMC50DOk9RNaPSG7L16Cj2ZMUrNhthqAEvE5Y5Q==",
       "requires": {
-        "message-event-channel": "^1.0.1"
+        "message-event-channel": "^1.1.0"
       }
     },
     "debug": {
@@ -4144,24 +4144,58 @@
       "version": "github:angular/flex-layout#dd367816157ea7a98dd1e9a9050f89b87d97639f",
       "from": "github:angular/flex-layout",
       "requires": {
-        "@angular/cdk": "^8.0.0-rc.1",
-        "@angular/common": "^8.0.0-rc.5",
-        "@angular/compiler": "^8.0.0-rc.5",
-        "@angular/core": "^8.0.0-rc.5",
-        "@angular/platform-browser": "^8.0.0-rc.5",
+        "@angular/cdk": "^9.2.2",
+        "@angular/common": "^9.1.5",
+        "@angular/compiler": "^9.1.5",
+        "@angular/core": "^9.1.5",
+        "@angular/platform-browser": "^9.1.5",
         "core-js": "^2.5.7",
         "karma-parallel": "^0.3.1",
         "rxjs": "^6.5.1",
         "systemjs": "0.19.43",
-        "tsickle": "^0.35.0",
+        "tsickle": "^0.37.1",
         "tslib": "^1.9.3",
-        "zone.js": "~0.9.1"
+        "zone.js": "~0.10.2"
       },
       "dependencies": {
+        "@angular/cdk": {
+          "version": "9.2.3",
+          "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-9.2.3.tgz",
+          "integrity": "sha512-tQr/yt8GNGsZ/DTT+PMq7XdRmL56hwVCyf8F12JQAawutSLfTfMb+S1lpN7L/0Pb/L5JBuCfG2HmXK7vHo02gw==",
+          "requires": {
+            "parse5": "^5.0.0"
+          }
+        },
+        "@angular/common": {
+          "version": "9.1.6",
+          "resolved": "https://registry.npmjs.org/@angular/common/-/common-9.1.6.tgz",
+          "integrity": "sha512-L9vw//wE+8QcSArOA411uJ68znnszCiPrbzSBV0BRZeadc7X68MwANA9qjtiTWZx5Xh9pNfHHwsCUyv2lUeinQ=="
+        },
+        "@angular/compiler": {
+          "version": "9.1.6",
+          "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.1.6.tgz",
+          "integrity": "sha512-tHOQEjWuWqSkrk6/vI6BK7uJnpAyFajCXPW37rH5xspF/aMbetrpoOiGBNUQg/HLaFh04nOAnnFntjLkW0ooaA=="
+        },
+        "@angular/core": {
+          "version": "9.1.6",
+          "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.1.6.tgz",
+          "integrity": "sha512-iXgPh5DebLwkMzLtQ6WKiv/mo4hpwMOwYex3O4F2CKToR2tKPnXbV5WC/ADGm0XYXiocSKQPiyL4ZrUjVeKEqA=="
+        },
+        "@angular/platform-browser": {
+          "version": "9.1.6",
+          "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-9.1.6.tgz",
+          "integrity": "sha512-ebQhbT0Z55vwlQwAY4+s3Bcf1Q4wEN5Yk43iCuVt4g2kFkg09UP0z8aYtbuh7VQDyv/W4TTIGX8smGBWstoedQ=="
+        },
         "core-js": {
           "version": "2.6.10",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
           "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+        },
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "optional": true
         },
         "rxjs": {
           "version": "6.5.3",
@@ -4170,6 +4204,16 @@
           "requires": {
             "tslib": "^1.9.0"
           }
+        },
+        "tsickle": {
+          "version": "0.37.1",
+          "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.37.1.tgz",
+          "integrity": "sha512-0GwgOJEnsmRsrONXCvcbAWY0CvdqF3UugPVoupUpA8Ul0qCPTuqqq0ou/hLqtKZOyyulzCP6MYRjb9/J1g9bJg=="
+        },
+        "zone.js": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
+          "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg=="
         }
       }
     },
@@ -6806,9 +6850,9 @@
       "dev": true
     },
     "message-event-channel": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/message-event-channel/-/message-event-channel-1.0.2.tgz",
-      "integrity": "sha512-v/mBYbGMi0AxRt12bwArtYiX1KlKG86ZW49irGgVNeR+SPUhE3euWhBEwxQzV/yXoeS8afjhslFNvCEGHgaACA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/message-event-channel/-/message-event-channel-1.1.0.tgz",
+      "integrity": "sha512-/6tBIQr8xmGiTkQZbLwiIxdsG21VcykYryk08cEdJdphEPYYCwi9ur/jSDfbQ6fY1urqo8TDZQ7dr7xJOrCqqw==",
       "requires": {
         "url-polyfill": "^1.1.7"
       }
@@ -6996,7 +7040,8 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
@@ -9481,7 +9526,8 @@
     "source-map": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true
     },
     "source-map-loader": {
       "version": "0.2.4",
@@ -10175,16 +10221,6 @@
         "yn": "^2.0.0"
       }
     },
-    "tsickle": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.35.0.tgz",
-      "integrity": "sha512-irsZLX4293YUl9TuwNC5Fy020eLSc4bC3LfKnxnx1oq5wmZD9zSP8qvNNTiwRmf2/rxH+58JINcTARDjuvn+oQ==",
-      "requires": {
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map": "^0.7.3"
-      }
-    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -10469,9 +10505,9 @@
       }
     },
     "url-polyfill": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.8.tgz",
-      "integrity": "sha512-Ey61F4FEqhcu1vHSOMmjl0Vd/RPRLEjMj402qszD/dhMBrVfoUsnIj8KSZo2yj+eIlxJGKFdnm6ES+7UzMgZ3Q=="
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.9.tgz",
+      "integrity": "sha512-q/R5sowGuRfKHm497swkV+s9cPYtZRkHxzpDjRhqLO58FwdWTIkt6Y/fJlznUD/exaKx/XnDzCYXz0V16ND7ow=="
     },
     "use": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dc-uiex-di",
+  "name": "dc-extension-di-transform",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -3135,9 +3135,9 @@
       "dev": true
     },
     "dc-extensions-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dc-extensions-sdk/-/dc-extensions-sdk-1.0.1.tgz",
-      "integrity": "sha512-b+HT3OQ3R8ZrdUEjBw9rYkhaqtKayjSUbamBU1O+2Bh8yMxyw8Kqbt4f+j2Yc8ulgq018PBcdNIElHSJ8aagcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dc-extensions-sdk/-/dc-extensions-sdk-1.0.3.tgz",
+      "integrity": "sha512-df7D60J9MaeAEysL/oNFPzihhNpSjmrppMrWpgWNH7RKPtRYo+Ld4l1z5A9wU2sDCpjSDOYc3bhfszd5RDrOww==",
       "requires": {
         "message-event-channel": "^1.0.1"
       }
@@ -10469,9 +10469,9 @@
       }
     },
     "url-polyfill": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.7.tgz",
-      "integrity": "sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.8.tgz",
+      "integrity": "sha512-Ey61F4FEqhcu1vHSOMmjl0Vd/RPRLEjMj402qszD/dhMBrVfoUsnIj8KSZo2yj+eIlxJGKFdnm6ES+7UzMgZ3Q=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "~8.2.0",
     "@angular/router": "~8.2.0",
     "@types/deep-equal": "^1.0.1",
-    "dc-extensions-sdk": "^1.0.1",
+    "dc-extensions-sdk": "^1.0.3",
     "deep-equal": "^1.1.0",
     "flex-layout-srcs": "github:angular/flex-layout",
     "hammerjs": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "~8.2.0",
     "@angular/router": "~8.2.0",
     "@types/deep-equal": "^1.0.1",
-    "dc-extensions-sdk": "^1.0.3",
+    "dc-extensions-sdk": "^1.1.0",
     "deep-equal": "^1.1.0",
     "flex-layout-srcs": "github:angular/flex-layout",
     "hammerjs": "^2.0.8",

--- a/src/app/api/dc-sdk.service.ts
+++ b/src/app/api/dc-sdk.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, EventEmitter } from '@angular/core';
-import { init, SDK } from 'dc-extensions-sdk';
+import { SDK } from 'dc-extensions-sdk';
 
 /** A simple wrapper around the dc-extensions-sdk */
 @Injectable({
@@ -12,7 +12,7 @@ export class DcSdkService {
 
   public async getSDK(): Promise<SDK> {
     if (this.sdk == null) {
-      this.sdk = init();
+      this.sdk = (window as any).extensionsSdkInstance as Promise<SDK>;
     }
     return await this.sdk;
   }

--- a/src/app/editor/di-image.service.ts
+++ b/src/app/editor/di-image.service.ts
@@ -44,7 +44,7 @@ export class DiImageService {
   }
 
   buildImageSrc(image: MediaImageLink): string {
-    return `http://${this.field.getImageHost()}/i/${image.endpoint}/${encodeURIComponent(image.name)}`;
+    return `https://${this.field.getImageHost()}/i/${image.endpoint}/${encodeURIComponent(image.name)}`;
   }
 
   async loadImage(data: DiTransformedImage) {

--- a/src/app/preview/spinner/spinner.component.ts
+++ b/src/app/preview/spinner/spinner.component.ts
@@ -12,8 +12,8 @@ export class SpinnerComponent implements OnInit, OnChanges {
   public dots: number[];
 
   lastMessage: string;
-  private newMessage: boolean;
-  private oldMessage: boolean;
+  newMessage: boolean;
+  oldMessage: boolean;
 
   constructor() {
   }

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
           dcExtensionsSdk.init().then(result => resolve(result)).catch(error => reject(error));
         }
 
-        script.src = 'https://unpkg.com/dc-extensions-sdk@1.0.3/dist/dc-extensions-sdk.umd.js';
+        script.src = 'https://unpkg.com/dc-extensions-sdk@1.1.0/dist/dc-extensions-sdk.umd.js';
         document.head.appendChild(script);
       });
     }

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,24 @@
   <meta http-equiv="X-UA-Compatible" />
   <title>DcUiexDi</title>
   <base href="/">
+  <script>
+    function initialize() {
+      // Initialize the SDK before the bundle loads, so that DC knows we're an extension and doesn't time out.
+
+      window.extensionsSdkInstance = new Promise((resolve, reject) => {
+        let script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.onload = () => {
+          dcExtensionsSdk.init().then(result => resolve(result)).catch(error => reject(error));
+        }
+
+        script.src = 'https://unpkg.com/dc-extensions-sdk@1.0.3/dist/dc-extensions-sdk.umd.js';
+        document.head.appendChild(script);
+      });
+    }
+
+    initialize();
+  </script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
Just fix a few small things:

- `http://` to `https://` for image URL building. Fixes mixed content issues.
- Update to latest version of `dc-extensions-sdk`, and load it separately from the rest of the bundle. This mitigates any issues that could come from the extension taking too long to load, for example on older connections.
  - A better way to do this would be creating a separate bundle for loading the extension and using a webpack plugin to make the script embed inline on the page (to mitigate request latency for requesting the js file separately). However, the angular cli does not provide any functionality like this, so our best bet is to just manually insert the script inline into the HTML. 
  - Depending on what future plans are, this might not play well with a "loading" display that DC might want to show in future while it's waiting for a connection. When initing early, we have made our existence known to DC, but we almost definitely aren't painting anything.

These should resolve a few issues we're seeing with the initial users of this extension.