### PR TITLE
feat: render title above the extension

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,5 @@
-<div style="height:500px">
+<div class="amp-root__title" *ngIf="title">{{title}}</div>
+<div class="amp-root__main">
 <amp-edit-toolbar [ngClass]="{'amp-root__topbar--hide': !showToolbar}"></amp-edit-toolbar>
 <amp-preview-canvas></amp-preview-canvas>
 </div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -5,6 +5,19 @@
   background-color: $color-lightest-grey;
 }
 
+.amp-root {
+  &__title {
+    color: #666;
+    font-size: 13px;
+    margin: 5px 0;
+  }
+
+  &__main {
+    height: 500px;
+    overflow: hidden;
+  }
+}
+
 .amp-root__topbar {
   &--hide {
     margin-top: -42px;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,7 +12,7 @@ import { DomSanitizer } from '@angular/platform-browser';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  title = 'dc-uiex-di';
+  title: string;
   data: DiTransformedImage;
 
   get showToolbar(): boolean {
@@ -22,5 +22,11 @@ export class AppComponent {
   constructor(private sdkService: DcSdkService, private editor: EditorService, private icons: MatIconRegistry,
               private sanitizer: DomSanitizer) {
     icons.addSvgIcon('delete', sanitizer.bypassSecurityTrustResourceUrl('./assets/icons/ic-asset-delete.svg'));
+
+    sdkService.getSDK().then((sdk) => {
+      const params = { ...sdk.params.installation, ...sdk.params.instance };
+
+      this.title = (params as any).title || sdk.field.schema.title;
+    });
   }
 }


### PR DESCRIPTION
This PR adds the ability for a title to be drawn above the extension.

The title can either be sourced from the schema field containing the `ui:extension`, or the `title` property in installation/instance parameters. The param title is preferred over the schema one, if both are present.