### PR TITLE
feat: MAN-1746 pass org via image-studio-sdk

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -49,7 +49,7 @@
               "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
-              "buildOptimizer": true,
+              "buildOptimizer": false,
               "budgets": [
                 {
                   "type": "initial",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dc-extension-di-transform",
       "version": "1.1.0",
       "dependencies": {
-        "@amplience/image-studio-sdk": "^0.1.0",
+        "@amplience/image-studio-sdk": "^0.4.0",
         "@angular/animations": "~8.2.0",
         "@angular/cdk": "~8.2.3",
         "@angular/common": "~8.2.0",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@amplience/image-studio-sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@amplience/image-studio-sdk/-/image-studio-sdk-0.1.0.tgz",
-      "integrity": "sha512-efmAm2AdKlhKhsKQ/SVBD4iity5AOUIFGpzcldNPCWjXJMo+ARPFPwz/ncXVDvJcoNVMYQzJzGP50qNIP2pj/w=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@amplience/image-studio-sdk/-/image-studio-sdk-0.4.0.tgz",
+      "integrity": "sha512-LxGXNONEz6Pt7f6yhGAnWRy1ZKR//etan1uKIckz0fANPCoPVVzCMU02iNZYWKF0tQPkxNG2CQ5eS/bK2re79A=="
     },
     "node_modules/@angular-devkit/architect": {
       "version": "0.802.2",
@@ -15070,9 +15070,9 @@
   },
   "dependencies": {
     "@amplience/image-studio-sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@amplience/image-studio-sdk/-/image-studio-sdk-0.1.0.tgz",
-      "integrity": "sha512-efmAm2AdKlhKhsKQ/SVBD4iity5AOUIFGpzcldNPCWjXJMo+ARPFPwz/ncXVDvJcoNVMYQzJzGP50qNIP2pj/w=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@amplience/image-studio-sdk/-/image-studio-sdk-0.4.0.tgz",
+      "integrity": "sha512-LxGXNONEz6Pt7f6yhGAnWRy1ZKR//etan1uKIckz0fANPCoPVVzCMU02iNZYWKF0tQPkxNG2CQ5eS/bK2re79A=="
     },
     "@angular-devkit/architect": {
       "version": "0.802.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dc-extension-di-transform",
       "version": "1.1.0",
       "dependencies": {
-        "@amplience/image-studio-sdk": "^0.4.0",
+        "@amplience/image-studio-sdk": "^0.5.1",
         "@angular/animations": "~8.2.0",
         "@angular/cdk": "~8.2.3",
         "@angular/common": "~8.2.0",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@amplience/image-studio-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@amplience/image-studio-sdk/-/image-studio-sdk-0.4.0.tgz",
-      "integrity": "sha512-LxGXNONEz6Pt7f6yhGAnWRy1ZKR//etan1uKIckz0fANPCoPVVzCMU02iNZYWKF0tQPkxNG2CQ5eS/bK2re79A=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@amplience/image-studio-sdk/-/image-studio-sdk-0.5.1.tgz",
+      "integrity": "sha512-pflkuIt2tXa6PA6jvY4Nu8StO/WBe+dMzZJ/brBSurRySapc0mPKddq4f1OBJHwxh2T2V9Z1u3Eodll2/CloJw=="
     },
     "node_modules/@angular-devkit/architect": {
       "version": "0.802.2",
@@ -15070,9 +15070,9 @@
   },
   "dependencies": {
     "@amplience/image-studio-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@amplience/image-studio-sdk/-/image-studio-sdk-0.4.0.tgz",
-      "integrity": "sha512-LxGXNONEz6Pt7f6yhGAnWRy1ZKR//etan1uKIckz0fANPCoPVVzCMU02iNZYWKF0tQPkxNG2CQ5eS/bK2re79A=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@amplience/image-studio-sdk/-/image-studio-sdk-0.5.1.tgz",
+      "integrity": "sha512-pflkuIt2tXa6PA6jvY4Nu8StO/WBe+dMzZJ/brBSurRySapc0mPKddq4f1OBJHwxh2T2V9Z1u3Eodll2/CloJw=="
     },
     "@angular-devkit/architect": {
       "version": "0.802.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "dependencies": {
-    "@amplience/image-studio-sdk": "^0.1.0",
+    "@amplience/image-studio-sdk": "^0.4.0",
     "@angular/animations": "~8.2.0",
     "@angular/cdk": "~8.2.3",
     "@angular/common": "~8.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "private": true,
   "dependencies": {
-    "@amplience/image-studio-sdk": "^0.4.0",
+    "@amplience/image-studio-sdk": "^0.5.1",
     "@angular/animations": "~8.2.0",
     "@angular/cdk": "~8.2.3",
     "@angular/common": "~8.2.0",

--- a/src/app/api/dc-sdk.service.ts
+++ b/src/app/api/dc-sdk.service.ts
@@ -4,7 +4,7 @@ import { DiTransformedImage } from '../model/di-transformed-image';
 
 export interface Parameters extends Params {
   installation: {
-    imageStudioUrl: string;
+    imageStudioDomain: string;
     mediaAssetsUrl: string;
   };
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -19,7 +19,7 @@ export class AppComponent {
   }
 
   constructor(private sdkService: DcSdkService, private editor: EditorService, private icons: MatIconRegistry,
-    private sanitizer: DomSanitizer) {
+              private sanitizer: DomSanitizer) {
     icons.addSvgIcon('delete', sanitizer.bypassSecurityTrustResourceUrl('./assets/icons/ic-asset-delete.svg'));
     icons.addSvgIcon('image_studio', sanitizer.bypassSecurityTrustResourceUrl('./assets/icons/ic-image-studio.svg'));
   }

--- a/src/app/editor/editor.service.ts
+++ b/src/app/editor/editor.service.ts
@@ -60,7 +60,7 @@ export class EditorService {
         this.field.updateField();
         break;
       case 'openImageStudio':
-        this.imageStudioService.openImageStudio(this.field.data.image)
+        this.imageStudioService.openImageStudio(this.field.data.image);
         break;
     }
 

--- a/src/app/image-studio/asset-library.service.ts
+++ b/src/app/image-studio/asset-library.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
+import { SDKImage, mimeTypeToFileExtension } from '@amplience/image-studio-sdk';
 import { HttpMethod } from 'dc-extensions-sdk/dist/types/lib/components/HttpClient';
 import { MediaImageLink } from 'dc-extensions-sdk/dist/types/lib/components/MediaLink';
 import { AssetPutPayload } from './types/AssetPutPayload';
 import { Asset } from './types/Asset';
 import { DcSdkService } from '../api/dc-sdk.service';
-import { SDKImage, mimeTypeToFileExtension } from '@amplience/image-studio-sdk/dist/esm';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/image-studio/asset-library.service.ts
+++ b/src/app/image-studio/asset-library.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpMethod } from "dc-extensions-sdk/dist/types/lib/components/HttpClient";
-import { MediaImageLink } from "dc-extensions-sdk/dist/types/lib/components/MediaLink";
-import { AssetPutPayload } from "./types/AssetPutPayload";
-import { Asset } from "./types/Asset";
+import { HttpMethod } from 'dc-extensions-sdk/dist/types/lib/components/HttpClient';
+import { MediaImageLink } from 'dc-extensions-sdk/dist/types/lib/components/MediaLink';
+import { AssetPutPayload } from './types/AssetPutPayload';
+import { Asset } from './types/Asset';
 import { DcSdkService } from '../api/dc-sdk.service';
 import { SDKImage, mimeTypeToFileExtension } from '@amplience/image-studio-sdk/dist/esm';
 
@@ -20,7 +20,7 @@ export class AssetLibraryService {
     const uploadedAsset = await sdk.assets.getById(id);
 
     if (!uploadedAsset) {
-      throw new Error("Asset does not exist");
+      throw new Error('Asset does not exist');
     }
     return uploadedAsset;
   }
@@ -29,18 +29,18 @@ export class AssetLibraryService {
     const sdk = await this.extensionSdk.getSDK();
     const mediaAssetsUrl = sdk.params.installation.mediaAssetsUrl;
     const response = await sdk.client.request({
-      url: mediaAssetsUrl || "https://api.amplience.net/v2/content/media/assets",
-      method: "PUT" as HttpMethod.PUT,
+      url: mediaAssetsUrl || 'https://api.amplience.net/v2/content/media/assets',
+      method: 'PUT' as HttpMethod.PUT,
       data: JSON.stringify(payload),
     });
 
     if (response.status !== 200) {
-      throw new Error("Error creating new asset");
+      throw new Error('Error creating new asset');
     }
 
     const data: any = response.data;
     if (!data && !data.content && !data.content[0]) {
-      throw new Error("Unexpected API response");
+      throw new Error('Unexpected API response');
     }
 
     return data.content[0];
@@ -53,18 +53,18 @@ export class AssetLibraryService {
     try {
       const sdk = await this.extensionSdk.getSDK();
       if (!sdk.hub.id) {
-        throw new Error("User has no HubId");
+        throw new Error('User has no HubId');
       }
 
       const fileExtension = mimeTypeToFileExtension(studioImage.mimeType);
 
       if (!fileExtension) {
-        throw new Error("Unable to determine image file extension");
+        throw new Error('Unable to determine image file extension');
       }
 
       const assetPutResponse = await this.putAsset({
         hubId: sdk.hub.id,
-        mode: "renameUnique",
+        mode: 'renameUnique',
         assets: [
           {
             src: studioImage.url,

--- a/src/app/image-studio/image-studio.service.ts
+++ b/src/app/image-studio/image-studio.service.ts
@@ -1,16 +1,16 @@
 import { Injectable } from '@angular/core';
 import { DcSdkService } from '../api/dc-sdk.service';
-import { AmplienceImageStudio } from "@amplience/image-studio-sdk/dist/esm";
+import { AmplienceImageStudio } from '@amplience/image-studio-sdk/dist/esm';
 import { DiFieldService } from '../editor/di-field.service';
 import { AssetLibraryService } from './asset-library.service';
 import {
   ImageSaveEventData,
   ImageStudioEventType,
   SDKEventType,
-} from "@amplience/image-studio-sdk";
+} from '@amplience/image-studio-sdk';
 
 @Injectable({
-  providedIn: "root",
+  providedIn: 'root',
 })
 export class ImageStudioService {
   constructor(
@@ -24,7 +24,7 @@ export class ImageStudioService {
       const sdkInstance = await this.sdkService.getSDK();
       const imageStudioUrl =
         sdkInstance.params.installation.imageStudioUrl ||
-        "https://app.amplience.net";
+        'https://app.amplience.net';
       const srcImage = await this.assetLibraryService.getAssetById(image.id);
       const imageStudio = new AmplienceImageStudio({
         domain: imageStudioUrl,
@@ -63,7 +63,7 @@ export class ImageStudioService {
         },
       ]);
     } catch (e) {
-      console.error("Image Studio error:", e);
+      console.error('Image Studio error:', e);
     }
   }
 }

--- a/src/app/image-studio/image-studio.service.ts
+++ b/src/app/image-studio/image-studio.service.ts
@@ -15,17 +15,23 @@ export class ImageStudioService {
   public async openImageStudio(image) {
     try {
       const sdkInstance = await this.sdkService.getSDK();
-      const imageStudioUrl = sdkInstance.params.installation.imageStudioUrl || "https://app.amplience.net/image-studio";
+      const imageStudioUrl =
+        sdkInstance.params.installation.imageStudioUrl ||
+        "https://app.amplience.net";
       const srcImage = await this.assetLibraryService.getAssetById(image.id);
       const imageStudio = new AmplienceImageStudio({
-        baseUrl: imageStudioUrl,
+        domain: imageStudioUrl,
       });
+
+      if (sdkInstance.hub.organizationId) {
+        imageStudio.withDecodedOrgId(sdkInstance.hub.organizationId);
+      }
 
       const studioResponse = await imageStudio.editImages([
         {
           url: srcImage.thumbURL,
           name: srcImage.name,
-          mimeType: srcImage.mimeType
+          mimeType: srcImage.mimeType,
         },
       ]);
 

--- a/src/app/image-studio/image-studio.service.ts
+++ b/src/app/image-studio/image-studio.service.ts
@@ -3,14 +3,21 @@ import { DcSdkService } from '../api/dc-sdk.service';
 import { AmplienceImageStudio } from "@amplience/image-studio-sdk/dist/esm";
 import { DiFieldService } from '../editor/di-field.service';
 import { AssetLibraryService } from './asset-library.service';
+import {
+  ImageSaveEventData,
+  ImageStudioEventType,
+  SDKEventType,
+} from "@amplience/image-studio-sdk";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: "root",
 })
 export class ImageStudioService {
-
-
-  constructor(private sdkService: DcSdkService, private assetLibraryService: AssetLibraryService, private diFieldService: DiFieldService) { }
+  constructor(
+    private sdkService: DcSdkService,
+    private assetLibraryService: AssetLibraryService,
+    private diFieldService: DiFieldService
+  ) {}
 
   public async openImageStudio(image) {
     try {
@@ -21,32 +28,40 @@ export class ImageStudioService {
       const srcImage = await this.assetLibraryService.getAssetById(image.id);
       const imageStudio = new AmplienceImageStudio({
         domain: imageStudioUrl,
+      }).withEventListener(ImageStudioEventType.ImageSave, async (data) => {
+        try {
+          const imageData = data as ImageSaveEventData;
+          if (imageData.image) {
+            const uploadedAsset = await this.assetLibraryService.uploadAsset(
+              imageData.image,
+              srcImage
+            );
+            const imageLink = this.assetLibraryService.createImageLinkFromAsset(
+              image,
+              uploadedAsset
+            );
+
+            this.diFieldService.updateImageValue(imageLink);
+            return SDKEventType.Success;
+          }
+          return SDKEventType.Fail;
+        } catch (error) {
+          console.error(error);
+          return SDKEventType.Fail;
+        }
       });
 
       if (sdkInstance.hub.organizationId) {
         imageStudio.withDecodedOrgId(sdkInstance.hub.organizationId);
       }
 
-      const studioResponse = await imageStudio.editImages([
+      await imageStudio.editImages([
         {
           url: srcImage.thumbURL,
           name: srcImage.name,
           mimeType: srcImage.mimeType,
         },
       ]);
-
-      if (studioResponse && studioResponse.image) {
-        const uploadedAsset = await this.assetLibraryService.uploadAsset(
-          studioResponse.image,
-          srcImage
-        );
-        const imageLink = this.assetLibraryService.createImageLinkFromAsset(
-          image,
-          uploadedAsset
-        );
-
-        this.diFieldService.updateImageValue(imageLink);
-      }
     } catch (e) {
       console.error("Image Studio error:", e);
     }

--- a/src/app/image-studio/image-studio.service.ts
+++ b/src/app/image-studio/image-studio.service.ts
@@ -51,12 +51,12 @@ export class ImageStudioService {
   public async openImageStudio(image) {
     try {
       const sdkInstance = await this.sdkService.getSDK();
-      const imageStudioUrl =
-        sdkInstance.params.installation.imageStudioUrl ||
+      const imageStudioDomain =
+        sdkInstance.params.installation.imageStudioDomain ||
         'https://app.amplience.net';
       const srcImage = await this.assetLibraryService.getAssetById(image.id);
       const imageStudio = new AmplienceImageStudio({
-        domain: imageStudioUrl,
+        domain: imageStudioDomain,
       }).withEventListener(ImageStudioEventType.ImageSave, async (data) => {
         return await this.handleOnSaveCallback(data, srcImage, image);
       });

--- a/src/app/image-studio/image-studio.service.ts
+++ b/src/app/image-studio/image-studio.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
-import { DcSdkService } from '../api/dc-sdk.service';
-import { AmplienceImageStudio } from '@amplience/image-studio-sdk/dist/esm';
 import {
+  AmplienceImageStudio,
   ImageSaveEventData,
   ImageStudioEventType,
   SDKEventType,
 } from '@amplience/image-studio-sdk';
+import { DcSdkService } from '../api/dc-sdk.service';
 import { MediaImageLink } from 'dc-extensions-sdk/dist/types/lib/components/MediaLink';
 import { DiFieldService } from '../editor/di-field.service';
 import { AssetLibraryService } from './asset-library.service';

--- a/src/app/preview/edit-toolbar/edit-toolbar.component.ts
+++ b/src/app/preview/edit-toolbar/edit-toolbar.component.ts
@@ -135,6 +135,6 @@ export class EditToolbarComponent implements OnInit {
   }
 
   async openImageStudio() {
-    this.imageStudioService.openImageStudio(this.field.data.image)
+    this.imageStudioService.openImageStudio(this.field.data.image);
   }
 }

--- a/src/app/preview/preview-canvas/preview-canvas.component.ts
+++ b/src/app/preview/preview-canvas/preview-canvas.component.ts
@@ -77,7 +77,7 @@ export class PreviewCanvasComponent implements OnInit, OnChanges {
   private lastFlip: boolean[] = [false, false];
 
   constructor(private myElem: ElementRef<Element>, private sanitizer: DomSanitizer, private dimage: DiImageService,
-    public editor: EditorService, private field: DiFieldService, private transform: ImageTransformerService) {
+              public editor: EditorService, private field: DiFieldService, private transform: ImageTransformerService) {
     this.dataUpdated(this.field.data);
     this.dimage.imageChanged.subscribe((image) => {
       this.updateCanvasTransform();


### PR DESCRIPTION
- bump to image-studio-sdk v0.5.1
  - pass org ID to image studio
  - update to make use of new event listener logic. Studio no longer closes on hitting save
- update studio base url
- rename installation param from `imageStudioUrl` -> `imageStudioDomain`