### PR TITLE
feat: expose source dimensions and delivered aspect ratio on the content item

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Check out `schema.json` for the content schema to use with this extension. In fu
 ## Parameters in Schema
 
 Put the following in the `params` object to change features of the extension:
+
 - `useVSE`: Set to true to use a VSE for fetching and rendering images. If this is false, images must be published to be seen.
 - `customVSE`: Set to whatever your custom VSE's hostname is. Do not include `http://` or a trailing slash. `useVSE` must be true.
 - `alwaysFullRes`: When true, the main preview image is always fetched at full resolution.
@@ -33,6 +34,18 @@ The extension has been fully integrated with Image Studio. This allows the user 
 
 You can find more information about using Image Studio in the [Amplience Studios docs](https://amplience.com/developers/docs/amplience-studios/)
 
+## Output fields (dimensions & aspect ratio)
+
+In addition to the transform parameters and prebaked `query`, the extension writes the following read-only fields into the content item so that a frontend can reserve the correct layout space up front and avoid Cumulative Layout Shift (CLS) — without making a second call to the DAM/DI metadata endpoint:
+
+- `srcWidth` / `srcHeight`: the intrinsic width and height (in pixels) of the source image, as reported by DI metadata. Useful as `next/image`-style intrinsic dimensions, or to derive the source aspect ratio.
+- `aspectRatio`: the aspect ratio (`width / height`, rounded to 4 dp) of the image that will actually be delivered — the crop rectangle when a crop is active, otherwise the source image. Bind this straight to CSS `aspect-ratio` for CLS-free rendering in both the cropped and uncropped cases.
+
+These values are populated automatically once the base image loads and are refreshed when the crop changes. They are optional in the schema, so content saved by earlier versions of the extension continues to load unchanged.
+
+> [!NOTE]
+> Rotation is not currently reflected in `aspectRatio` (e.g. a 90°/270° rotation would invert the delivered ratio), but rotation is currently disabled in this extension anyway, so it's just noting here in case it is enabled in the future.
+
 ## How to install
 
 ### Register Extension
@@ -41,12 +54,12 @@ This extension needs to be [registered](https://amplience.com/docs/development/r
 
 ![Setup](media/setup.png)
 
-* Category: Content Field
-* Label: DI Image Transformation _(this will appear as the tab title in the Dashboard)_
-* Name: di-image-transformation _(needs to be unique with the Hub)_
-* URL: [https://di-transform.extensions.content.amplience.net](https://di-transform.extensions.content.amplience.net)
-* Description: DI Image Transformation _(can be left blank, if you wish)_
-* Initial height: 500
+- Category: Content Field
+- Label: DI Image Transformation _(this will appear as the tab title in the Dashboard)_
+- Name: di-image-transformation _(needs to be unique with the Hub)_
+- URL: [https://di-transform.extensions.content.amplience.net](https://di-transform.extensions.content.amplience.net)
+- Description: DI Image Transformation _(can be left blank, if you wish)_
+- Initial height: 500
 
 Note:
 You can use our deployed version of this extension (builds from the "production" branch) -
@@ -54,7 +67,6 @@ You can use our deployed version of this extension (builds from the "production"
 [di-transform.extensions.content.amplience.net](di-transform.extensions.content.amplience.net)
 
 _As this is an open source project you're welcome to host your own "fork" of this project. You can use any standard static hosting service (Netlify, Amplify, Vercel, etc.) if you wish._
-
 
 ##### Permissions
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Check out `schema.json` for the content schema to use with this extension. In fu
 ## Parameters in Schema
 
 Put the following in the `params` object to change features of the extension:
-
 - `useVSE`: Set to true to use a VSE for fetching and rendering images. If this is false, images must be published to be seen.
 - `customVSE`: Set to whatever your custom VSE's hostname is. Do not include `http://` or a trailing slash. `useVSE` must be true.
 - `alwaysFullRes`: When true, the main preview image is always fetched at full resolution.
@@ -54,12 +53,12 @@ This extension needs to be [registered](https://amplience.com/docs/development/r
 
 ![Setup](media/setup.png)
 
-- Category: Content Field
-- Label: DI Image Transformation _(this will appear as the tab title in the Dashboard)_
-- Name: di-image-transformation _(needs to be unique with the Hub)_
-- URL: [https://di-transform.extensions.content.amplience.net](https://di-transform.extensions.content.amplience.net)
-- Description: DI Image Transformation _(can be left blank, if you wish)_
-- Initial height: 500
+* Category: Content Field
+* Label: DI Image Transformation _(this will appear as the tab title in the Dashboard)_
+* Name: di-image-transformation _(needs to be unique with the Hub)_
+* URL: [https://di-transform.extensions.content.amplience.net](https://di-transform.extensions.content.amplience.net)
+* Description: DI Image Transformation _(can be left blank, if you wish)_
+* Initial height: 500
 
 Note:
 You can use our deployed version of this extension (builds from the "production" branch) -
@@ -67,6 +66,7 @@ You can use our deployed version of this extension (builds from the "production"
 [di-transform.extensions.content.amplience.net](di-transform.extensions.content.amplience.net)
 
 _As this is an open source project you're welcome to host your own "fork" of this project. You can use any standard static hosting service (Netlify, Amplify, Vercel, etc.) if you wish._
+
 
 ##### Permissions
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ You can find more information about using Image Studio in the [Amplience Studios
 
 In addition to the transform parameters and prebaked `query`, the extension writes the following read-only fields into the content item so that a frontend can reserve the correct layout space up front and avoid Cumulative Layout Shift (CLS) — without making a second call to the DAM/DI metadata endpoint:
 
-- `srcWidth` / `srcHeight`: the intrinsic width and height (in pixels) of the source image, as reported by DI metadata. Useful as `next/image`-style intrinsic dimensions, or to derive the source aspect ratio.
-- `aspectRatio`: the aspect ratio (`width / height`, rounded to 4 dp) of the image that will actually be delivered — the crop rectangle when a crop is active, otherwise the source image. Bind this straight to CSS `aspect-ratio` for CLS-free rendering in both the cropped and uncropped cases.
+All three describe the **delivered** image — the crop rectangle when a crop is active, otherwise the source image:
+
+- `width` / `height`: the intrinsic width and height (in pixels) of the delivered image. Usable as `next/image`-style intrinsic dimensions, and as an upper bound so the frontend doesn't request (and upscale) beyond the real resolution.
+- `aspectRatio`: `width / height`, rounded to 4 dp. Bind this straight to CSS `aspect-ratio` for CLS-free rendering in both the cropped and uncropped cases.
 
 These values are populated automatically once the base image loads and are refreshed when the crop changes. They are optional in the schema, so content saved by earlier versions of the extension continues to load unchanged.
 
 > [!NOTE]
-> Rotation is not currently reflected in `aspectRatio` (e.g. a 90°/270° rotation would invert the delivered ratio), but rotation is currently disabled in this extension anyway, so it's just noting here in case it is enabled in the future.
+> Rotation is not currently reflected in these fields (e.g. a 90°/270° rotation would swap width and height), but rotation is currently disabled in this extension anyway, so it's just noting here in case it is enabled in the future.
 
 ## How to install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dc-extension-di-transform",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-extension-di-transform",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "dependencies": {
         "@amplience/image-studio-sdk": "^0.5.1",
         "@angular/animations": "~8.2.0",
@@ -218,6 +218,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-8.2.11.tgz",
       "integrity": "sha512-u0PSR2uvSqn3ovgGlw2H8ZueyYN42SLir2Yn3+7sGE+LcYOSTjyJ/GIgjV8jWddvPbx7KYzFRCs6bEMpBsMXYg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -229,6 +230,7 @@
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-8.2.3.tgz",
       "integrity": "sha512-ZwO5Sn720RA2YvBqud0JAHkZXjmjxM0yNzCO8RVtRE9i8Gl26Wk0j0nQeJkVm4zwv2QO8MwbKUKGTMt8evsokA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.7.1"
       },
@@ -309,6 +311,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-8.2.11.tgz",
       "integrity": "sha512-AN8KKv13rVN1vwyVszZ1POvuUequ7jNC7Af/IDuxTJXKUDCI44dvjYQI0hbCicDDV+XZgjdkd4CBIiLCZRKnOQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -321,6 +324,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.11.tgz",
       "integrity": "sha512-Qnh07i04s0LZECEKu9/NHwdRutfEs9N3y8f0uMdC+m7Cjy3guvmLtriAMdnxlH3KFFFSnugM6Ng6+gII8tZI6A==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       }
@@ -1314,6 +1318,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-8.2.11.tgz",
       "integrity": "sha512-TRfoJPcTjjiFh1dquqDc7LDI4sqD/LPCC9y2HP4r8644xJawhPJ0Ms6gWaeobCeP2k0vKsjrFmbPWeolOig/YA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -1342,6 +1347,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-8.2.11.tgz",
       "integrity": "sha512-9sXLvAgscGwoE7k9kwRPogPSx8B8kT+kbXCvkL3Az+C+HrEuQ3rwMIJEFO+OhOCkRwrdUniKsp7GHLw94jAqtQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -1377,6 +1383,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-8.2.11.tgz",
       "integrity": "sha512-bKDkC7kpNvgvRQfw4s+84GJWrY7MPFx9d1bUk9OPQzEBAjzRX+E6IFlqfTpZRGy4m5rbSzBk3bpZdqcZSJM98A==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -1991,6 +1998,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5021,17 +5029,6 @@
         "yarn": ">= 1.19.1"
       }
     },
-    "node_modules/flex-layout-srcs/node_modules/@angular/animations": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-9.1.6.tgz",
-      "integrity": "sha512-7Pp7aqNNcH4fu1BnOVpvqJJHjE7RZ5K1oD396OWCh35pgpLowLSpFjhbVhzGrcAuxHyKnnHSX3etLn2hDaHxmQ==",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "@angular/core": "9.1.6",
-        "tslib": "^1.10.0"
-      }
-    },
     "node_modules/flex-layout-srcs/node_modules/@angular/cdk": {
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-9.2.3.tgz",
@@ -5049,6 +5046,7 @@
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-9.1.6.tgz",
       "integrity": "sha512-L9vw//wE+8QcSArOA411uJ68znnszCiPrbzSBV0BRZeadc7X68MwANA9qjtiTWZx5Xh9pNfHHwsCUyv2lUeinQ==",
+      "peer": true,
       "peerDependencies": {
         "@angular/core": "9.1.6",
         "rxjs": "^6.5.3",
@@ -5067,6 +5065,7 @@
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.1.6.tgz",
       "integrity": "sha512-iXgPh5DebLwkMzLtQ6WKiv/mo4hpwMOwYex3O4F2CKToR2tKPnXbV5WC/ADGm0XYXiocSKQPiyL4ZrUjVeKEqA==",
+      "peer": true,
       "peerDependencies": {
         "rxjs": "^6.5.3",
         "tslib": "^1.10.0",
@@ -5106,6 +5105,7 @@
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
       "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -5145,7 +5145,8 @@
     "node_modules/flex-layout-srcs/node_modules/zone.js": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
-      "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg=="
+      "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
+      "peer": true
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
@@ -6893,7 +6894,8 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",
       "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/jasmine-spec-reporter": {
       "version": "4.2.1",
@@ -7119,6 +7121,7 @@
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-2.0.1.tgz",
       "integrity": "sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "jasmine-core": "^3.3"
       },
@@ -10718,6 +10721,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
       "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -12353,13 +12357,15 @@
     "node_modules/tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "peer": true
     },
     "node_modules/tslint": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.15.0.tgz",
       "integrity": "sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -12464,6 +12470,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
       "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13731,6 +13738,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.38.0.tgz",
       "integrity": "sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -15065,7 +15073,8 @@
     "node_modules/zone.js": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.9.1.tgz",
-      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag=="
+      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag==",
+      "peer": true
     }
   },
   "dependencies": {
@@ -15200,6 +15209,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-8.2.11.tgz",
       "integrity": "sha512-u0PSR2uvSqn3ovgGlw2H8ZueyYN42SLir2Yn3+7sGE+LcYOSTjyJ/GIgjV8jWddvPbx7KYzFRCs6bEMpBsMXYg==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -15208,6 +15218,7 @@
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-8.2.3.tgz",
       "integrity": "sha512-ZwO5Sn720RA2YvBqud0JAHkZXjmjxM0yNzCO8RVtRE9i8Gl26Wk0j0nQeJkVm4zwv2QO8MwbKUKGTMt8evsokA==",
+      "peer": true,
       "requires": {
         "parse5": "^5.0.0",
         "tslib": "^1.7.1"
@@ -15274,6 +15285,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-8.2.11.tgz",
       "integrity": "sha512-AN8KKv13rVN1vwyVszZ1POvuUequ7jNC7Af/IDuxTJXKUDCI44dvjYQI0hbCicDDV+XZgjdkd4CBIiLCZRKnOQ==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -15282,6 +15294,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.11.tgz",
       "integrity": "sha512-Qnh07i04s0LZECEKu9/NHwdRutfEs9N3y8f0uMdC+m7Cjy3guvmLtriAMdnxlH3KFFFSnugM6Ng6+gII8tZI6A==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -16065,6 +16078,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-8.2.11.tgz",
       "integrity": "sha512-TRfoJPcTjjiFh1dquqDc7LDI4sqD/LPCC9y2HP4r8644xJawhPJ0Ms6gWaeobCeP2k0vKsjrFmbPWeolOig/YA==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -16081,6 +16095,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-8.2.11.tgz",
       "integrity": "sha512-9sXLvAgscGwoE7k9kwRPogPSx8B8kT+kbXCvkL3Az+C+HrEuQ3rwMIJEFO+OhOCkRwrdUniKsp7GHLw94jAqtQ==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -16103,6 +16118,7 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-8.2.11.tgz",
       "integrity": "sha512-bKDkC7kpNvgvRQfw4s+84GJWrY7MPFx9d1bUk9OPQzEBAjzRX+E6IFlqfTpZRGy4m5rbSzBk3bpZdqcZSJM98A==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -16650,6 +16666,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19184,14 +19201,6 @@
         "zone.js": "~0.9.1"
       },
       "dependencies": {
-        "@angular/animations": {
-          "version": "9.1.6",
-          "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-9.1.6.tgz",
-          "integrity": "sha512-7Pp7aqNNcH4fu1BnOVpvqJJHjE7RZ5K1oD396OWCh35pgpLowLSpFjhbVhzGrcAuxHyKnnHSX3etLn2hDaHxmQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {}
-        },
         "@angular/cdk": {
           "version": "https://registry.npmjs.org/@angular/cdk/-/cdk-9.2.3.tgz",
           "integrity": "sha512-tQr/yt8GNGsZ/DTT+PMq7XdRmL56hwVCyf8F12JQAawutSLfTfMb+S1lpN7L/0Pb/L5JBuCfG2HmXK7vHo02gw==",
@@ -19203,6 +19212,7 @@
           "version": "9.1.6",
           "resolved": "https://registry.npmjs.org/@angular/common/-/common-9.1.6.tgz",
           "integrity": "sha512-L9vw//wE+8QcSArOA411uJ68znnszCiPrbzSBV0BRZeadc7X68MwANA9qjtiTWZx5Xh9pNfHHwsCUyv2lUeinQ==",
+          "peer": true,
           "requires": {}
         },
         "@angular/compiler": {
@@ -19214,6 +19224,7 @@
           "version": "9.1.6",
           "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.1.6.tgz",
           "integrity": "sha512-iXgPh5DebLwkMzLtQ6WKiv/mo4hpwMOwYex3O4F2CKToR2tKPnXbV5WC/ADGm0XYXiocSKQPiyL4ZrUjVeKEqA==",
+          "peer": true,
           "requires": {}
         },
         "@angular/platform-browser": {
@@ -19236,6 +19247,7 @@
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
           "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+          "peer": true,
           "requires": {
             "tslib": "^1.9.0"
           }
@@ -19259,7 +19271,8 @@
         "zone.js": {
           "version": "0.10.3",
           "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
-          "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg=="
+          "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
+          "peer": true
         }
       }
     },
@@ -20667,7 +20680,8 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",
       "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "jasmine-spec-reporter": {
       "version": "4.2.1",
@@ -21477,6 +21491,7 @@
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-2.0.1.tgz",
       "integrity": "sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "jasmine-core": "^3.3"
       }
@@ -23787,6 +23802,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
       "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -25168,13 +25184,15 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "peer": true
     },
     "tslint": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.15.0.tgz",
       "integrity": "sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -25256,7 +25274,8 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
       "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "uglify-js": {
       "version": "3.6.2",
@@ -26290,6 +26309,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.38.0.tgz",
       "integrity": "sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -27360,7 +27380,8 @@
     "zone.js": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.9.1.tgz",
-      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag=="
+      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag==",
+      "peer": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,7 +218,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-8.2.11.tgz",
       "integrity": "sha512-u0PSR2uvSqn3ovgGlw2H8ZueyYN42SLir2Yn3+7sGE+LcYOSTjyJ/GIgjV8jWddvPbx7KYzFRCs6bEMpBsMXYg==",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -230,7 +229,6 @@
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-8.2.3.tgz",
       "integrity": "sha512-ZwO5Sn720RA2YvBqud0JAHkZXjmjxM0yNzCO8RVtRE9i8Gl26Wk0j0nQeJkVm4zwv2QO8MwbKUKGTMt8evsokA==",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.7.1"
       },
@@ -311,7 +309,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-8.2.11.tgz",
       "integrity": "sha512-AN8KKv13rVN1vwyVszZ1POvuUequ7jNC7Af/IDuxTJXKUDCI44dvjYQI0hbCicDDV+XZgjdkd4CBIiLCZRKnOQ==",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -324,7 +321,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.11.tgz",
       "integrity": "sha512-Qnh07i04s0LZECEKu9/NHwdRutfEs9N3y8f0uMdC+m7Cjy3guvmLtriAMdnxlH3KFFFSnugM6Ng6+gII8tZI6A==",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       }
@@ -1318,7 +1314,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-8.2.11.tgz",
       "integrity": "sha512-TRfoJPcTjjiFh1dquqDc7LDI4sqD/LPCC9y2HP4r8644xJawhPJ0Ms6gWaeobCeP2k0vKsjrFmbPWeolOig/YA==",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -1347,7 +1342,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-8.2.11.tgz",
       "integrity": "sha512-9sXLvAgscGwoE7k9kwRPogPSx8B8kT+kbXCvkL3Az+C+HrEuQ3rwMIJEFO+OhOCkRwrdUniKsp7GHLw94jAqtQ==",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -1383,7 +1377,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-8.2.11.tgz",
       "integrity": "sha512-bKDkC7kpNvgvRQfw4s+84GJWrY7MPFx9d1bUk9OPQzEBAjzRX+E6IFlqfTpZRGy4m5rbSzBk3bpZdqcZSJM98A==",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -1998,7 +1991,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5029,6 +5021,17 @@
         "yarn": ">= 1.19.1"
       }
     },
+    "node_modules/flex-layout-srcs/node_modules/@angular/animations": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-9.1.6.tgz",
+      "integrity": "sha512-7Pp7aqNNcH4fu1BnOVpvqJJHjE7RZ5K1oD396OWCh35pgpLowLSpFjhbVhzGrcAuxHyKnnHSX3etLn2hDaHxmQ==",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@angular/core": "9.1.6",
+        "tslib": "^1.10.0"
+      }
+    },
     "node_modules/flex-layout-srcs/node_modules/@angular/cdk": {
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-9.2.3.tgz",
@@ -5046,7 +5049,6 @@
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-9.1.6.tgz",
       "integrity": "sha512-L9vw//wE+8QcSArOA411uJ68znnszCiPrbzSBV0BRZeadc7X68MwANA9qjtiTWZx5Xh9pNfHHwsCUyv2lUeinQ==",
-      "peer": true,
       "peerDependencies": {
         "@angular/core": "9.1.6",
         "rxjs": "^6.5.3",
@@ -5065,7 +5067,6 @@
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.1.6.tgz",
       "integrity": "sha512-iXgPh5DebLwkMzLtQ6WKiv/mo4hpwMOwYex3O4F2CKToR2tKPnXbV5WC/ADGm0XYXiocSKQPiyL4ZrUjVeKEqA==",
-      "peer": true,
       "peerDependencies": {
         "rxjs": "^6.5.3",
         "tslib": "^1.10.0",
@@ -5105,7 +5106,6 @@
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
       "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -5145,8 +5145,7 @@
     "node_modules/flex-layout-srcs/node_modules/zone.js": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
-      "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
-      "peer": true
+      "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg=="
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
@@ -6894,8 +6893,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",
       "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/jasmine-spec-reporter": {
       "version": "4.2.1",
@@ -7121,7 +7119,6 @@
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-2.0.1.tgz",
       "integrity": "sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "jasmine-core": "^3.3"
       },
@@ -10721,7 +10718,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
       "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -12357,15 +12353,13 @@
     "node_modules/tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "peer": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "node_modules/tslint": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.15.0.tgz",
       "integrity": "sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -12470,7 +12464,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
       "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13738,7 +13731,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.38.0.tgz",
       "integrity": "sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -15073,8 +15065,7 @@
     "node_modules/zone.js": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.9.1.tgz",
-      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag==",
-      "peer": true
+      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag=="
     }
   },
   "dependencies": {
@@ -15209,7 +15200,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-8.2.11.tgz",
       "integrity": "sha512-u0PSR2uvSqn3ovgGlw2H8ZueyYN42SLir2Yn3+7sGE+LcYOSTjyJ/GIgjV8jWddvPbx7KYzFRCs6bEMpBsMXYg==",
-      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -15218,7 +15208,6 @@
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-8.2.3.tgz",
       "integrity": "sha512-ZwO5Sn720RA2YvBqud0JAHkZXjmjxM0yNzCO8RVtRE9i8Gl26Wk0j0nQeJkVm4zwv2QO8MwbKUKGTMt8evsokA==",
-      "peer": true,
       "requires": {
         "parse5": "^5.0.0",
         "tslib": "^1.7.1"
@@ -15285,7 +15274,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-8.2.11.tgz",
       "integrity": "sha512-AN8KKv13rVN1vwyVszZ1POvuUequ7jNC7Af/IDuxTJXKUDCI44dvjYQI0hbCicDDV+XZgjdkd4CBIiLCZRKnOQ==",
-      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -15294,7 +15282,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.11.tgz",
       "integrity": "sha512-Qnh07i04s0LZECEKu9/NHwdRutfEs9N3y8f0uMdC+m7Cjy3guvmLtriAMdnxlH3KFFFSnugM6Ng6+gII8tZI6A==",
-      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -16078,7 +16065,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-8.2.11.tgz",
       "integrity": "sha512-TRfoJPcTjjiFh1dquqDc7LDI4sqD/LPCC9y2HP4r8644xJawhPJ0Ms6gWaeobCeP2k0vKsjrFmbPWeolOig/YA==",
-      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -16095,7 +16081,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-8.2.11.tgz",
       "integrity": "sha512-9sXLvAgscGwoE7k9kwRPogPSx8B8kT+kbXCvkL3Az+C+HrEuQ3rwMIJEFO+OhOCkRwrdUniKsp7GHLw94jAqtQ==",
-      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -16118,7 +16103,6 @@
       "version": "8.2.11",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-8.2.11.tgz",
       "integrity": "sha512-bKDkC7kpNvgvRQfw4s+84GJWrY7MPFx9d1bUk9OPQzEBAjzRX+E6IFlqfTpZRGy4m5rbSzBk3bpZdqcZSJM98A==",
-      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -16666,7 +16650,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19201,6 +19184,14 @@
         "zone.js": "~0.9.1"
       },
       "dependencies": {
+        "@angular/animations": {
+          "version": "9.1.6",
+          "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-9.1.6.tgz",
+          "integrity": "sha512-7Pp7aqNNcH4fu1BnOVpvqJJHjE7RZ5K1oD396OWCh35pgpLowLSpFjhbVhzGrcAuxHyKnnHSX3etLn2hDaHxmQ==",
+          "optional": true,
+          "peer": true,
+          "requires": {}
+        },
         "@angular/cdk": {
           "version": "https://registry.npmjs.org/@angular/cdk/-/cdk-9.2.3.tgz",
           "integrity": "sha512-tQr/yt8GNGsZ/DTT+PMq7XdRmL56hwVCyf8F12JQAawutSLfTfMb+S1lpN7L/0Pb/L5JBuCfG2HmXK7vHo02gw==",
@@ -19212,7 +19203,6 @@
           "version": "9.1.6",
           "resolved": "https://registry.npmjs.org/@angular/common/-/common-9.1.6.tgz",
           "integrity": "sha512-L9vw//wE+8QcSArOA411uJ68znnszCiPrbzSBV0BRZeadc7X68MwANA9qjtiTWZx5Xh9pNfHHwsCUyv2lUeinQ==",
-          "peer": true,
           "requires": {}
         },
         "@angular/compiler": {
@@ -19224,7 +19214,6 @@
           "version": "9.1.6",
           "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.1.6.tgz",
           "integrity": "sha512-iXgPh5DebLwkMzLtQ6WKiv/mo4hpwMOwYex3O4F2CKToR2tKPnXbV5WC/ADGm0XYXiocSKQPiyL4ZrUjVeKEqA==",
-          "peer": true,
           "requires": {}
         },
         "@angular/platform-browser": {
@@ -19247,7 +19236,6 @@
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
           "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
-          "peer": true,
           "requires": {
             "tslib": "^1.9.0"
           }
@@ -19271,8 +19259,7 @@
         "zone.js": {
           "version": "0.10.3",
           "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
-          "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
-          "peer": true
+          "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg=="
         }
       }
     },
@@ -20680,8 +20667,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",
       "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "jasmine-spec-reporter": {
       "version": "4.2.1",
@@ -21491,7 +21477,6 @@
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-2.0.1.tgz",
       "integrity": "sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "jasmine-core": "^3.3"
       }
@@ -23802,7 +23787,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
       "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
-      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -25184,15 +25168,13 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "peer": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tslint": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.15.0.tgz",
       "integrity": "sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -25274,8 +25256,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
       "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "uglify-js": {
       "version": "3.6.2",
@@ -26309,7 +26290,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.38.0.tgz",
       "integrity": "sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -27380,8 +27360,7 @@
     "zone.js": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.9.1.tgz",
-      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag==",
-      "peer": true
+      "integrity": "sha512-GkPiJL8jifSrKReKaTZ5jkhrMEgXbXYC+IPo1iquBjayRa0q86w3Dipjn8b415jpitMExe9lV8iTsv8tk3DGag=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-extension-di-transform",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/schema.json
+++ b/schema.json
@@ -96,19 +96,19 @@
           "description": "A query string baked with all the above parameters.",
           "type": "string"
         },
-        "srcWidth": {
-          "title": "Source Width",
-          "description": "Intrinsic width of the source image in pixels (from DI metadata). Written by the extension so consumers can reserve layout space without a second call.",
+        "width": {
+          "title": "Width",
+          "description": "Intrinsic width in pixels of the delivered image: the crop rectangle when a crop is active, otherwise the source image. Written by the extension so consumers can reserve layout space (avoid CLS) and cap request resolution without a second call.",
           "type": "number"
         },
-        "srcHeight": {
-          "title": "Source Height",
-          "description": "Intrinsic height of the source image in pixels (from DI metadata). Written by the extension so consumers can reserve layout space without a second call.",
+        "height": {
+          "title": "Height",
+          "description": "Intrinsic height in pixels of the delivered image: the crop rectangle when a crop is active, otherwise the source image.",
           "type": "number"
         },
         "aspectRatio": {
           "title": "Aspect Ratio",
-          "description": "Aspect ratio (width / height) of the delivered image: the crop rectangle when a crop is active, otherwise the source image. Bind directly to CSS aspect-ratio to avoid layout shift (CLS).",
+          "description": "Aspect ratio (width / height) of the delivered image, rounded to 4 dp. Bind directly to CSS aspect-ratio to avoid layout shift (CLS).",
           "type": "number"
         }
       },

--- a/schema.json
+++ b/schema.json
@@ -95,6 +95,21 @@
           "title": "DI Query String",
           "description": "A query string baked with all the above parameters.",
           "type": "string"
+        },
+        "srcWidth": {
+          "title": "Source Width",
+          "description": "Intrinsic width of the source image in pixels (from DI metadata). Written by the extension so consumers can reserve layout space without a second call.",
+          "type": "number"
+        },
+        "srcHeight": {
+          "title": "Source Height",
+          "description": "Intrinsic height of the source image in pixels (from DI metadata). Written by the extension so consumers can reserve layout space without a second call.",
+          "type": "number"
+        },
+        "aspectRatio": {
+          "title": "Aspect Ratio",
+          "description": "Aspect ratio (width / height) of the delivered image: the crop rectangle when a crop is active, otherwise the source image. Bind directly to CSS aspect-ratio to avoid layout shift (CLS).",
+          "type": "number"
         }
       },
       "ui:extension": {

--- a/src/app/editor/di-image.service.spec.ts
+++ b/src/app/editor/di-image.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@angular/core/testing';
+import { EventEmitter } from '@angular/core';
 
 import { DiImageService } from './di-image.service';
+import { DiFieldService } from './di-field.service';
 
 describe('DiImageService', () => {
   beforeEach(() => TestBed.configureTestingModule({}));
@@ -8,5 +10,39 @@ describe('DiImageService', () => {
   it('should be created', () => {
     const service: DiImageService = TestBed.get(DiImageService);
     expect(service).toBeTruthy();
+  });
+});
+
+describe('DiImageService.updateDimensionMetadata', () => {
+  let field: any;
+  let service: DiImageService;
+
+  beforeEach(() => {
+    // Minimal fake field so we can test the logic without the full DI graph.
+    field = { data: { crop: [0, 0, 0, 0] }, fieldUpdated: new EventEmitter(), isCropActive: () => false };
+    service = new DiImageService(field as DiFieldService, {} as any);
+    service.imageWidth = 800;
+    service.imageHeight = 600;
+  });
+
+  it('writes the source dimensions and ratio when uncropped', () => {
+    expect(service.updateDimensionMetadata()).toBe(true);
+    expect(field.data.width).toBe(800);
+    expect(field.data.height).toBe(600);
+    expect(field.data.aspectRatio).toBe(1.3333); // 800/600, rounded to 4dp
+  });
+
+  it('uses the crop rectangle dimensions when a crop is active', () => {
+    field.isCropActive = () => true;
+    field.data.crop = [0, 0, 100, 200];
+    service.updateDimensionMetadata();
+    expect(field.data.width).toBe(100);
+    expect(field.data.height).toBe(200);
+    expect(field.data.aspectRatio).toBe(0.5); // crop width/height
+  });
+
+  it('returns false when nothing changed', () => {
+    service.updateDimensionMetadata();
+    expect(service.updateDimensionMetadata()).toBe(false);
   });
 });

--- a/src/app/editor/di-image.service.ts
+++ b/src/app/editor/di-image.service.ts
@@ -115,8 +115,9 @@ export class DiImageService {
     this.imageChanged.emit(this.image);
   }
 
-  // Stores source dimensions & delivered aspect ratio (crop if active, else source) on the field.
-  // Returns true if anything changed so callers can decide whether to persist.
+  // Stores the delivered image dimensions & aspect ratio on the field: the crop rectangle
+  // (source pixels) when a crop is active, else the source image. Returns true if anything
+  // changed so callers can decide whether to persist.
   // Rotation (disabled in this extension anyway) is not accounted for.
   updateDimensionMetadata(): boolean {
     const data = this.field.data;
@@ -124,26 +125,25 @@ export class DiImageService {
       return false;
     }
 
+    let width = this.imageWidth;
+    let height = this.imageHeight;
+    if (this.field.isCropActive()) {
+      width = Math.round(data.crop[2]);
+      height = Math.round(data.crop[3]);
+    }
+
     let changed = false;
 
-    if (data.srcWidth !== this.imageWidth) {
-      data.srcWidth = this.imageWidth;
+    if (data.width !== width) {
+      data.width = width;
       changed = true;
     }
-    if (data.srcHeight !== this.imageHeight) {
-      data.srcHeight = this.imageHeight;
+    if (data.height !== height) {
+      data.height = height;
       changed = true;
     }
-
-    let aspectWidth = this.imageWidth;
-    let aspectHeight = this.imageHeight;
-    if (this.field.isCropActive()) {
-      aspectWidth = data.crop[2];
-      aspectHeight = data.crop[3];
-    }
-
-    if (aspectWidth > 0 && aspectHeight > 0) {
-      const aspectRatio = Math.round((aspectWidth / aspectHeight) * 10000) / 10000;
+    if (width > 0 && height > 0) {
+      const aspectRatio = Math.round((width / height) * 10000) / 10000;
       if (data.aspectRatio !== aspectRatio) {
         data.aspectRatio = aspectRatio;
         changed = true;

--- a/src/app/editor/di-image.service.ts
+++ b/src/app/editor/di-image.service.ts
@@ -115,9 +115,9 @@ export class DiImageService {
     this.imageChanged.emit(this.image);
   }
 
-  // Stores source dimensions and delivered aspect ratio (crop if active, else source) on
-  // the field. Returns true if anything changed, so callers can decide whether to persist.
-  // Rotation (disabled in this extension) is not accounted for.
+  // Stores source dimensions & delivered aspect ratio (crop if active, else source) on the field.
+  // Returns true if anything changed so callers can decide whether to persist.
+  // Rotation (disabled in this extension anyway) is not accounted for.
   updateDimensionMetadata(): boolean {
     const data = this.field.data;
     if (data == null || !(this.imageWidth > 0) || !(this.imageHeight > 0)) {

--- a/src/app/editor/di-image.service.ts
+++ b/src/app/editor/di-image.service.ts
@@ -106,7 +106,51 @@ export class DiImageService {
       const bound = this.cropPx || this.getRotatedBounds();
       this.poiPx = [bound[0] + bound[2] * data.poi.x, bound[1] + bound[3] * data.poi.y];
     }
+
+    // dimensions are now known - persist them so consumers avoid a second metadata call.
+    if (this.updateDimensionMetadata()) {
+      this.field.updateField();
+    }
+
     this.imageChanged.emit(this.image);
+  }
+
+  // Stores source dimensions and delivered aspect ratio (crop if active, else source) on
+  // the field. Returns true if anything changed, so callers can decide whether to persist.
+  // Rotation (disabled in this extension) is not accounted for.
+  updateDimensionMetadata(): boolean {
+    const data = this.field.data;
+    if (data == null || !(this.imageWidth > 0) || !(this.imageHeight > 0)) {
+      return false;
+    }
+
+    let changed = false;
+
+    if (data.srcWidth !== this.imageWidth) {
+      data.srcWidth = this.imageWidth;
+      changed = true;
+    }
+    if (data.srcHeight !== this.imageHeight) {
+      data.srcHeight = this.imageHeight;
+      changed = true;
+    }
+
+    let aspectWidth = this.imageWidth;
+    let aspectHeight = this.imageHeight;
+    if (this.field.isCropActive()) {
+      aspectWidth = data.crop[2];
+      aspectHeight = data.crop[3];
+    }
+
+    if (aspectWidth > 0 && aspectHeight > 0) {
+      const aspectRatio = Math.round((aspectWidth / aspectHeight) * 10000) / 10000;
+      if (data.aspectRatio !== aspectRatio) {
+        data.aspectRatio = aspectRatio;
+        changed = true;
+      }
+    }
+
+    return changed;
   }
 
   private rotatePoint(point: number[], angle: number): number[] {
@@ -167,6 +211,7 @@ export class DiImageService {
     }
     data.crop = this.cropPx;
     this.savePOI(true);
+    this.updateDimensionMetadata();
     this.field.updateField();
   }
 

--- a/src/app/model/di-transformed-image.ts
+++ b/src/app/model/di-transformed-image.ts
@@ -15,6 +15,12 @@ export interface DiTransformedImage {
 
   aspectLock: string;
   query: string;
+
+  // Source image dimensions and delivered aspect ratio, for reserving layout space (CLS).
+  // Optional for backwards compatibility.
+  srcWidth?: number;
+  srcHeight?: number;
+  aspectRatio?: number;
 }
 
 export interface DiTransformPoi {

--- a/src/app/model/di-transformed-image.ts
+++ b/src/app/model/di-transformed-image.ts
@@ -16,9 +16,10 @@ export interface DiTransformedImage {
   aspectLock: string;
   query: string;
 
-  // Source image dimensions & delivered aspect ratio, for reserving layout space (CLS) (Optional for backwards compatibility)
-  srcWidth?: number;
-  srcHeight?: number;
+  // Delivered image dimensions & aspect ratio (incl post-crop changes)
+  // Useful for reserving layout space to prevent CLS
+  width?: number;
+  height?: number;
   aspectRatio?: number;
 }
 

--- a/src/app/model/di-transformed-image.ts
+++ b/src/app/model/di-transformed-image.ts
@@ -16,7 +16,7 @@ export interface DiTransformedImage {
   aspectLock: string;
   query: string;
 
-  // Source image dimensions and delivered aspect ratio, for reserving layout space (CLS) (Optional for backwards compatibility)
+  // Source image dimensions & delivered aspect ratio, for reserving layout space (CLS) (Optional for backwards compatibility)
   srcWidth?: number;
   srcHeight?: number;
   aspectRatio?: number;

--- a/src/app/model/di-transformed-image.ts
+++ b/src/app/model/di-transformed-image.ts
@@ -16,8 +16,7 @@ export interface DiTransformedImage {
   aspectLock: string;
   query: string;
 
-  // Source image dimensions and delivered aspect ratio, for reserving layout space (CLS).
-  // Optional for backwards compatibility.
+  // Source image dimensions and delivered aspect ratio, for reserving layout space (CLS) (Optional for backwards compatibility)
   srcWidth?: number;
   srcHeight?: number;
   aspectRatio?: number;

--- a/src/app/preview/crop-toolbar/crop-toolbar.component.ts
+++ b/src/app/preview/crop-toolbar/crop-toolbar.component.ts
@@ -46,6 +46,7 @@ export class CropToolbarComponent implements OnInit {
     }
 
     this.field.data.crop = crop.slice(0);
+    this.image.updateDimensionMetadata();
     this.field.updateField();
   }
 

--- a/src/app/preview/edit-toolbar/edit-toolbar.component.ts
+++ b/src/app/preview/edit-toolbar/edit-toolbar.component.ts
@@ -112,12 +112,14 @@ export class EditToolbarComponent implements OnInit {
   clearCrop() {
     this.field.data.crop = [0, 0, 0, 0];
     this.field.data.aspectLock = 'clear';
+    this.dimage.updateDimensionMetadata();
     this.field.updateField();
   }
 
   poiMode() {
     this.field.data.crop = [0, 0, 0, 0];
     this.field.data.aspectLock = 'poi';
+    this.dimage.updateDimensionMetadata();
     this.field.updateField();
     // this.editor.setMode(PreviewMode.POI);
   }


### PR DESCRIPTION
Access to this data without a second metadata call is useful for combatting CLS.

I've kept this as a light-weight footprint, only additional changes, and left the fields optional to allow backwards-compatibility.

It solves a limitation I kept hitting in Frasers, as well as recently while trying to build a solid baseplate for the latest accelerator.

Also links to [CUSTREQ-405](https://ampliencedev.atlassian.net/browse/CUSTREQ-405) and [FEEDBACK-170](https://ampliencedev.atlassian.net/browse/FEEDBACK-170) which were raised by @seantaplin, and [IDEA-184](https://ampliencedev.atlassian.net/browse/IDEA-184) raised by @neilmistryamplience.

## Jira Issue Summary

The recurring theme is that while **image w/h metadata has been available in DI since DI-472 (2015)** via `$this.src.width`/`$this.metadata.image.width`, it requires a **separate metadata request** or DI URL expressions. The long-standing gap — represented by [CUSTREQ-405: Return Image Metadata in the Response](https://ampliencedev.atlassian.net/browse/CUSTREQ-405) (still Backlog) and [FEEDBACK-170: Retrieving image metadata in JSON content](https://ampliencedev.atlassian.net/browse/FEEDBACK-170) (still Triaged) — is that this metadata **isn't returned inline in the content JSON response**, forcing customers to make extra API calls.

## Solution Summary

This updates the extension to persist three read-only fields onto the transformed image content item — `srcWidth`, `srcHeight`, and `aspectRatio` — so that a frontend can reserve the correct layout space up front and avoid Cumulative Layout Shift (CLS) **without a second call** to the DAM/DI metadata endpoint.

## Motivation

When rendering a DI image, the frontend can request a width easily, but it doesn't know the height because the aspect ratio can be anything. That makes it impossible to reserve the right amount of space before the image loads, causing CLS. It's only a non-issue when the site enforces a fixed aspect ratio (e.g. all heroes 16:9) or when an editor has selected a crop — but on sites where image aspect ratios are driven by whatever content editors pick, and no crop is selected (the common case), there's no way to know the shape ahead of time.

To render CLS-free you need 2 of 3 of `width` / `height` / `aspectRatio`. The frontend already knows the requested width, so exposing the aspect ratio lets height fall into place.

This is a long-standing, recurring gap — it's come up across multiple implementations and is currently blocking clean image rendering in the [Quadratic Light accelerator](https://github.com/mattisherwood/quadratic-lite/).

## What changed

The extension already fetches the source image's intrinsic dimensions from DI metadata (`…/i/{endpoint}/{name}.json`) and uses them internally for crop/POI maths and preview scaling — they just weren't saved. This PR writes them (plus a derived ratio) into the field value:

- `srcWidth` / `srcHeight` — intrinsic source dimensions in pixels. Usable directly as `next/image`-style intrinsic width/height, or to derive the source ratio.
- `aspectRatio` — aspect ratio (`width / height`, rounded to 4 dp) of the image that will actually be **delivered**: the crop rectangle when a crop is active, otherwise the source image. Bind straight to CSS `aspect-ratio`.

Populated once the base image loads, and refreshed on crop save.

## Design note

`aspectRatio` is the *delivered* ratio, not the immutable source ratio. This is deliberate: an "initial aspect ratio that never changes" would be wrong whenever a crop is applied (the frontend would reserve the wrong box and reintroduce CLS). By tracking the delivered image, a single field is correct in both the cropped and uncropped cases. The raw `srcWidth`/`srcHeight` are still exposed for anyone who wants the immutable source shape, so a separate `initialAspectRatio` field isn't needed.

## Backwards compatibility

All three fields are optional in the schema and interface, so content saved by earlier versions loads unchanged. Existing consumers are unaffected. No new network calls are introduced.

## Testing

- `tsc --noEmit` passes on the app project.
- Verified fields populate on image load, update when a crop is added/changed, and revert to the source ratio when the crop is cleared.

## Notes / limitations

- Rotation is not currently reflected in `aspectRatio` (e.g. a 90°/270° rotation would invert the delivered ratio), but rotation is currently disabled in this extension anyway, so I've just noted it in the README in case it is enabled in the future.
- App version bumped to 1.3.0.


[CUSTREQ-405]: https://ampliencedev.atlassian.net/browse/CUSTREQ-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEEDBACK-170]: https://ampliencedev.atlassian.net/browse/FEEDBACK-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDEA-184]: https://ampliencedev.atlassian.net/browse/IDEA-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ